### PR TITLE
feat: remove split screen maps to use default maps

### DIFF
--- a/lua/config/keymaps.lua
+++ b/lua/config/keymaps.lua
@@ -1,9 +1,3 @@
 -- Keymaps are automatically loaded on the VeryLazy event
 -- Default keymaps that are always set: https://github.com/LazyVim/LazyVim/blob/main/lua/lazyvim/config/keymaps.lua
 -- Add any additional keymaps here
-local keymap = vim.keymap
-local defaultOpts = { noremap = true, silent = true }
-
--- -- Split Window
-keymap.set("n", "ss", ":split<Return>", defaultOpts)
-keymap.set("n", "sv", ":vsplit<Return>", defaultOpts)


### PR DESCRIPTION
This PR return the split screen maps to default version